### PR TITLE
improve create-update-agent-skill skill description

### DIFF
--- a/core/skills/system/create-update-agent-skill/SKILL.md
+++ b/core/skills/system/create-update-agent-skill/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: create-update-agent-skill
-description: Create or update agent skills following the agent skill specification. Use when user asks to create a new skill or update an existing skill.
+description: >-
+  Create, add, edit, or update agent skills by generating YAML frontmatter, writing markdown instructions, organizing reference files, and validating against the agent skill specification. Use when the user asks to create a new skill, add a skill, edit or modify an existing skill, update skill instructions, write a SKILL.md, teach the agent a new ability, or build a reusable skill from scratch.
 ---
 
 # AI Builder - Create/Update Agent Skill


### PR DESCRIPTION
hey @X-School-Academy, thanks for building skill-pilot. really like the Dev Swarm system and how you've organized the multi-role skill architecture. kudos for the repo! just starred it.

ran your create-update-agent-skill skill through some evals and noticed a quick win that took it from `~65%` to `~79%` agent performance:

- expanded frontmatter description with capability statement + trigger terms like _create a new skill_, _edit skill instructions_, _teach the agent a new ability_, _build a reusable skill_

these were easy changes to bring the skill in line with what **performs well against Anthropic's best practices**. honest disclosure, I work at tessl.io where we build tooling around this. not a pitch, just fixes that were straightforward to make.

you've got `159` skills, if you want to do it yourself, spin up Claude Code and run `tessl skill review`. alternatively, let me know if you'd like an automatic review in your repo via GitHub Actions. it doesn't require signup, and this means you and your contributors get an instant quality signal before you have to review yourself.