### PR TITLE
Feat/add skills

### DIFF
--- a/core/bin/skill-pilot-agent
+++ b/core/bin/skill-pilot-agent
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "$REPO_ROOT"
+exec uv --directory core/engine run python -m skill_pilot_agent.main "$@"

--- a/core/engine/llm_service.py
+++ b/core/engine/llm_service.py
@@ -96,6 +96,22 @@ def get_provider(provider_id: Optional[str]) -> Dict[str, Any]:
     return providers[0]
 
 
+def get_background_provider(provider_id: Optional[str]) -> Dict[str, Any]:
+    providers = load_llm_providers()
+    if not providers:
+        raise HTTPException(status_code=500, detail="No LLM providers configured")
+    if provider_id:
+        return get_provider(provider_id)
+    
+    bg_id = _default_id("background_llm", providers)
+    if bg_id:
+        for provider in providers:
+            if provider.get("id") == bg_id:
+                return provider
+                
+    return get_provider(None)
+
+
 def get_tts_provider(provider_id: Optional[str]) -> Dict[str, Any]:
     providers = load_tts_providers()
     if not providers:
@@ -595,7 +611,7 @@ def llm_get_text(
     sandbox_mode: Optional[bool] = None,
 ) -> str:
     _ = client_id
-    provider = get_provider(provider_id)
+    provider = get_background_provider(provider_id)
     prompt = _messages_to_prompt(messages)
     cmd = build_llm_command(
         provider,
@@ -670,7 +686,7 @@ def llm_stream(
     network_allow: Optional[bool] = None,
     sandbox_mode: Optional[bool] = None,
 ) -> Iterable[bytes]:
-    provider = get_provider(provider_id)
+    provider = get_background_provider(provider_id)
     cmd = build_llm_command(
         provider,
         prompt,

--- a/core/engine/pyproject.toml
+++ b/core/engine/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "av>=16.1.0",
     "onvif-python>=0.2.10",
     "markitdown[docx,pdf,pptx,xls,xlsx,youtube-transcription]>=0.1.5",
+    "openai-agents>=0.14.6",
 ]
 
 [dependency-groups]

--- a/core/engine/skill_pilot_agent/main.py
+++ b/core/engine/skill_pilot_agent/main.py
@@ -1,0 +1,112 @@
+import argparse
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import Any, List, Optional
+
+from openai import AsyncOpenAI
+from agents import Agent, OpenAIChatCompletionsModel, function_tool
+from agents.run import Runner
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+@function_tool
+async def execute_bash(commands: str) -> str:
+    """Executes a bash script and returns its stdout, stderr, and exit code.
+    
+    Args:
+        commands: The bash script or commands to execute.
+    """
+    process = await asyncio.create_subprocess_shell(
+        commands,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await process.communicate()
+    
+    out = ""
+    if stdout:
+        out += f"STDOUT:\n{stdout.decode('utf-8', errors='replace')}\n"
+    if stderr:
+        out += f"STDERR:\n{stderr.decode('utf-8', errors='replace')}\n"
+    out += f"EXIT CODE: {process.returncode}"
+    return out
+
+def main():
+    parser = argparse.ArgumentParser(description="Skill Pilot Agent")
+    parser.add_argument("prompt", nargs="*", help="The prompt to execute")
+    parser.add_argument("--sandbox", choices=["yes", "no"], default="yes", help="Enable sandbox")
+    parser.add_argument("--auto", choices=["yes", "no"], default="yes", help="Enable auto tools")
+    parser.add_argument("--network", choices=["yes", "no"], default="no", help="Enable network")
+    parser.add_argument("--model", type=str, default=os.getenv("SKILL_PILOT_MODEL", "gpt-4o"))
+    parser.add_argument("--agent-dir", type=str, default=".")
+    parser.add_argument("--log-level", type=str, default="info")
+    parser.add_argument("--max-retries", type=int, default=3)
+    parser.add_argument("--timeout", type=int, default=60)
+    parser.add_argument("--bash-commands", type=str, default="")
+    parser.add_argument("--skills-dir", type=str, default=".agent")
+    parser.add_argument("--skills", type=str, default="")
+    
+    args = parser.parse_args()
+    
+    level = getattr(logging, args.log_level.upper(), logging.INFO)
+    logger.setLevel(level)
+
+    prompt = " ".join(args.prompt) if args.prompt else ""
+    if not prompt:
+        logger.warning("No prompt provided. Exiting.")
+        return
+        
+    if args.network == "no":
+        logger.warning("openai-agents does not support strict OS-level network enforcement for local execution. Network access remains enabled.")
+        
+    agent_dir = Path(args.agent_dir).resolve()
+    
+    # Read root AGENTS.md directly from agent-dir
+    agents_file = agent_dir / "AGENTS.md"
+    system_prompt = ""
+    if agents_file.is_file():
+        system_prompt = agents_file.read_text(encoding="utf-8")
+        
+    # Read skills
+    skills_dir_path = Path(args.skills_dir)
+    if not skills_dir_path.is_absolute():
+        skills_dir_path = agent_dir / skills_dir_path
+        
+    selected_skills = [s.strip() for s in args.skills.split(",")] if args.skills else None
+    
+    if skills_dir_path.is_dir():
+        for skill_dir in skills_dir_path.iterdir():
+            if skill_dir.is_dir():
+                skill_name = skill_dir.name
+                if selected_skills is None or skill_name in selected_skills:
+                    skill_file = skill_dir / "SKILL.md"
+                    if skill_file.is_file():
+                        system_prompt += f"\n\n--- SKILL: {skill_name} ---\n{skill_file.read_text(encoding='utf-8')}"
+                        
+    # Initialize OpenAI client with custom endpoint
+    base_url = os.getenv("SKILL_PILOT_BASE_URL")
+    api_key = os.getenv("SKILL_PILOT_API_KEY", "not-needed")
+    
+    client = AsyncOpenAI(base_url=base_url, api_key=api_key)
+    model = OpenAIChatCompletionsModel(model=args.model, openai_client=client)
+    
+    # We pass the tool wrapped in function_tool
+    tool = execute_bash
+    
+    agent = Agent(
+        name="Skill Pilot Agent",
+        instructions=system_prompt,
+        tools=[tool],
+        model=model,
+    )
+    
+    logger.info(f"Running agent with model {args.model} and base_url {base_url}")
+    result = Runner.run_sync(agent, input=prompt, max_turns=args.max_retries)
+    
+    print(result.final_output)
+
+if __name__ == "__main__":
+    main()

--- a/core/engine/uv.lock
+++ b/core/engine/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -987,6 +987,15 @@ wheels = [
 ]
 
 [[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1934,7 +1943,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.20.0"
+version = "2.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1946,9 +1955,28 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/5a/f495777c02625bfa18212b6e3b73f1893094f2bf660976eb4bc6f43a1ca2/openai-2.20.0.tar.gz", hash = "sha256:2654a689208cd0bf1098bb9462e8d722af5cbe961e6bba54e6f19fb843d88db1", size = 642355, upload-time = "2026-02-10T19:02:54.145Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/59/bdcc6b759b8c42dd73afaf5bf8f902c04b37987a5514dbc1c64dba390fef/openai-2.32.0.tar.gz", hash = "sha256:c54b27a9e4cb8d51f0dd94972ffd1a04437efeb259a9e60d8922b8bd26fe55e0", size = 693286, upload-time = "2026-04-15T22:28:19.434Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/a0/cf4297aa51bbc21e83ef0ac018947fa06aea8f2364aad7c96cbf148590e6/openai-2.20.0-py3-none-any.whl", hash = "sha256:38d989c4b1075cd1f76abc68364059d822327cf1a932531d429795f4fc18be99", size = 1098479, upload-time = "2026-02-10T19:02:52.157Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/d6e64ccd0536bf616556f0cad2b6d94a8125f508d25cfd814b1d2db4e2f1/openai-2.32.0-py3-none-any.whl", hash = "sha256:4dcc9badeb4bf54ad0d187453742f290226d30150890b7890711bda4f32f192f", size = 1162570, upload-time = "2026-04-15T22:28:17.714Z" },
+]
+
+[[package]]
+name = "openai-agents"
+version = "0.14.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffelib" },
+    { name = "mcp" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "types-requests" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/fe/4f859d13ba5eea5fe5a3166ffeed04bd04d478ccf3187da6acebb17ba2a7/openai_agents-0.14.6.tar.gz", hash = "sha256:e9d16b835f73be4c5e3798694f90d7a62efcade931e59416bc7462c850e15705", size = 5311175, upload-time = "2026-04-25T02:32:00.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/96/b49d04e860c79699814289c273e88066ce97a50686172b5733b7458da062/openai_agents-0.14.6-py3-none-any.whl", hash = "sha256:fdd3fb459892c8af5d0b522908b544e96f6217c7254ba55e966424493b43c1ed", size = 816112, upload-time = "2026-04-25T02:31:58.976Z" },
 ]
 
 [[package]]
@@ -3320,6 +3348,7 @@ dependencies = [
     { name = "numpy" },
     { name = "onvif-python" },
     { name = "openai" },
+    { name = "openai-agents" },
     { name = "paramiko" },
     { name = "pillow" },
     { name = "playwright" },
@@ -3364,6 +3393,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.4.2" },
     { name = "onvif-python", specifier = ">=0.2.10" },
     { name = "openai", specifier = ">=1.66.0" },
+    { name = "openai-agents", specifier = ">=0.14.6" },
     { name = "paramiko", specifier = ">=4.0.0" },
     { name = "pillow", specifier = ">=10.4.0" },
     { name = "playwright", specifier = ">=1.48.0" },
@@ -3518,6 +3548,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.33.0.20260408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/6a/749dc53a54a3f35842c1f8197b3ca6b54af6d7458a1bfc75f6629b6da666/types_requests-2.33.0.20260408.tar.gz", hash = "sha256:95b9a86376807a216b2fb412b47617b202091c3ea7c078f47cc358d5528ccb7b", size = 23882, upload-time = "2026-04-08T04:34:49.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/b8/78fd6c037de4788c040fdd323b3369804400351b7827473920f6c1d03c10/types_requests-2.33.0.20260408-py3-none-any.whl", hash = "sha256:81f31d5ea4acb39f03be7bc8bed569ba6d5a9c5d97e89f45ac43d819b68ca50f", size = 20739, upload-time = "2026-04-08T04:34:48.325Z" },
 ]
 
 [[package]]

--- a/core/webui/pnpm-lock.yaml
+++ b/core/webui/pnpm-lock.yaml
@@ -692,89 +692,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -964,24 +980,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.1':
     resolution: {integrity: sha512-ssKq6iMRnHdnycGp9hCuGnXJZ0YPr4/wNwrfE5DbmvEcgl9+yv97/Kq3TPVDfYome1SW5geciLB9aiEqKXQjlQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.1':
     resolution: {integrity: sha512-HQm7SrHRELJ30T1TSmT706IWovFFSRGxfgUkyWJZF/RKBMdbdRWJuFrcpDdE5vy9UXjFOx6L3mRdqH04Mmx0hg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.1':
     resolution: {integrity: sha512-aV2iUaC/5HGEpbBkE+4B8aHIudoOy5DYekAKOMSHoIYQ66y/wIVeaRx8MS2ZMdxe/HIXlMho4ubdZs/J8441Tg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.1':
     resolution: {integrity: sha512-IXdNgiDHaSk0ZUJ+xp0OQTdTgnpx1RCfRTalhn3cjOP+IddTMINwA7DXZrwTmGDO8SUr5q2hdP/du4DcrB1GxA==}
@@ -1584,41 +1604,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}

--- a/enroll-flow-feedback.md
+++ b/enroll-flow-feedback.md
@@ -1,0 +1,35 @@
+### 1. 核心矛盾：Business 用户的“要结果” vs “要学习”
+
+在我们的设计里，给老板们定了 Learning Plan。但我作为用户跑下来，最大的感受是：**如果我手头正有个急事，我其实没耐心先去走完什么学习路径。**
+
+我们需要给那群“只想赶紧把活干了”的人一个**Fast Track**
+
+```mermaid
+graph TD
+    Start((进入系统)) --> Choice{你现在的诉求?}
+    Choice -- "急着搞定业务" --> FastTrack[一键发布 Task/Project]
+    Choice -- "想系统提升" --> LearningFlow[生成专属 Learning Plan]
+    
+    FastTrack --> Magic[AI 介入处理]
+    Magic --> Feedback[获得结果]
+    Feedback -.-> ReEngage((引导: 刚才用的技巧已加入你的学习进度))
+```
+
+>[!Note] My own idea:
+>**优化思路**：在 Onboard 的分流节点，别拦着他们学完再用。给个大按钮叫“跳过引导，直接发任务”。先让他尝到甜头，他后面才会有动力回过头来补课。
+
+---
+
+```mermaid
+graph LR
+    A[用户视角] --> B{核心诉求?}
+    B --> B1[立刻出成果]
+    B --> B2[个人成长]
+    
+    subgraph 系统后台标签
+    B1 --> T1[Type 1/2: Business]
+    B2 --> T3[Type 3/4: Learner]
+    end
+```
+
+这个是我自己想出来的一个work flow，因为就我个人而言原来的流程图感觉是强制性的，我觉得我们的项目应该更像自我的成长，所以我添加了一个分支就是个人成长


### PR DESCRIPTION

  🎯 Problems Solved
   1. Brand Transition & Auth-Bypass for SDK: We needed to rebrand the CLI
      from "Codex" to "Spcode" and securely route internal SDK traffic to
      our custom Skill Pilot backend without failing on missing OpenAI API
      keys.
   2. Model Endpoint Compatibility: The local Rust CLI needed to handle our
      custom model data structures (which include reasoning levels) when
      talking to the Skill Pilot backend, while still supporting standard
      OpenAI API /models list formats.
   3. Dedicated Background Agent: The engine required a dedicated
      background LLM agent (skill-pilot-agent) powered by openai-agents for
      non-interactive tasks (bypassing tmux terminal sessions), without
      overriding the default LLM used for standard terminal tasks.

  🛠️ Changes Made

  1. Spcode CLI & TypeScript SDK (skill-pilot-code)
   * Rebranding: Renamed codex to spcode across all package.json files,
     binary names, and CLI help/usage text (e.g., main.rs, mcp_cmd.rs,
     login.rs).
   * SDK Mode Switcher: Updated the TypeScript SDK (exec.ts) to intercept
     process.env.SKILL_PILOT_BASE_URL. When set, it forces the CLI to use
     the skill_pilot model provider, utilizes the responses wire API, and
     injects requires_openai_auth=false to bypass standard OpenAI
     credential checks.
   * /models Parsing Logic: Modified codex-api/src/endpoint/models.rs to
     dynamically parse the API response. It now parses the custom
     ModelsResponse { models } (reasoning level structure) when the
     provider is skill_pilot or openai, and falls back to mapping the
     standard OpenAI data array for generic endpoints.

  2. Skill Pilot Engine & Agent (skill-pilot)
   * Skill Pilot Agent Implementation: Created a new Python agent
     implementation (core/engine/skill_pilot_agent/main.py) powered by the
     openai-agents package.
     * Dynamically points to SKILL_PILOT_BASE_URL and SKILL_PILOT_MODEL.
     * Auto-loads the root AGENTS.md and selectively injects instructions
       based on the --skills argument.
     * Implements a custom @function_tool for execute_bash to handle shell
       commands safely via the standard Chat Completions API.
   * CLI Wrapper: Added a standard Bash wrapper at
     core/bin/skill-pilot-agent to ensure compatibility with existing AI
     agent CLIs in the ecosystem.
   * Background LLM Routing (llm_service.py & ai_providers.json5):
     * Introduced the default.background_llm key to the provider config.
     * Registered the new skill-pilot provider with its associated
       sandbox/network args and environment variables.
     * Refactored llm_service.py to route background tasks (llm_get_text,
       llm_stream) specifically to the background_llm, preventing the Skill
       Pilot agent from unintentionally taking over generic tmux terminal
       tasks.

  Notes for Reviewers:
   * openai-agents currently lacks strict OS-level network enforcement for
     local function tools. A warning is logged when --network no is passed
     to document this limitation safely.