### PR TITLE
Fix Codex JSON detection for absolute binary path

### DIFF
--- a/core/engine/llm_service.py
+++ b/core/engine/llm_service.py
@@ -396,7 +396,8 @@ def _llm_subprocess_env(provider_env: Dict[str, str]) -> Dict[str, str]:
 
 
 def _provider_uses_codex_json(provider: Dict[str, Any]) -> bool:
-    return str(provider.get("bin") or "").strip().lower() == "codex" and "--json" in _string_list(provider, "args")
+    bin_name = Path(str(provider.get("bin") or "").strip()).name.lower()
+    return bin_name == "codex" and "--json" in _string_list(provider, "args")
 
 
 def _provider_uses_gemini_json(provider: Dict[str, Any]) -> bool:


### PR DESCRIPTION
This PR fixes Codex JSON provider detection when the Codex binary is configured with an absolute path.

Previously, `_provider_uses_codex_json()` only returned true when `provider["bin"]` was exactly `"codex"`. If the provider used an absolute path such as `/home/user/.nvm/versions/node/v22.22.2/bin/codex`, Codex JSONL output was not recognised as Codex output.

This change compares `Path(bin).name == "codex"`, so both short command names and absolute Codex binary paths are supported.

Tested locally with an absolute Codex binary path and confirmed:
- `_provider_uses_codex_json()` returns true
- `llm_get_json()` correctly extracts the assistant message text from Codex JSONL output
- the video workflow can generate `output/final_video.mp4`